### PR TITLE
Fix typos across repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A typical sequence of operations is as follows:
 
 ### Recovery from errors
 
-Ocasionally an error such as `No route to host` appears. We are
+Occasionally an error such as `No route to host` appears. We are
 currently investigating its exact cause, but for the moment you should
 just destroy the partially created cyber range and repeat the creation
 process.

--- a/instantiation/logs_preparation/pcap_ddosattack_generator.sh
+++ b/instantiation/logs_preparation/pcap_ddosattack_generator.sh
@@ -2,7 +2,7 @@
 
 # The flow of the emulation will be as followed:
 # - Install the tool hping3 for the base image
-# - Start tcpdump on the host to listen to traffic comming to the virtual bridge virbr0 (kvm)
+# - Start tcpdump on the host to listen to traffic coming to the virtual bridge virbr0 (kvm)
 # - Copy the script attacks_emulation/launch_ddos.sh to the base image and start the attack to nic virbr0 of the host
 # - Terminate the attack after two seconds
 # - Change the victim address in the pcap file (currently virbr0 addr) to image's address

--- a/instantiation/logs_preparation/pcap_dosattack_generator.sh
+++ b/instantiation/logs_preparation/pcap_dosattack_generator.sh
@@ -2,7 +2,7 @@
 
 # The flow of the emulation will be as followed:
 # - Install the tool hping3 for the base image
-# - Start tcpdump on the host to listen to traffic comming to the virtual bridge virbr0 (kvm)
+# - Start tcpdump on the host to listen to traffic coming to the virtual bridge virbr0 (kvm)
 # - Copy the script attacks_emulation/launch_dos.sh to the base image and start the attack to nic virbr0 of the host
 #   with user-specified source address (source_addr) and destination port (dport)
 # - Terminate the attack after two seconds

--- a/instantiation/logs_preparation/pcap_sshattack_generator.sh
+++ b/instantiation/logs_preparation/pcap_sshattack_generator.sh
@@ -37,7 +37,7 @@ sudo tcprewrite -D ${virbr_addr}/32:${image_addr}/32 -i ${cr_dir}virbr0_3.pcap -
 # change timestamp of noise file and merge with the attack pcap file
 sudo python3 ${abs_path}${inst_dir}/logs_preparation/mergePcap.py ${noise_level} ${file_name} ${abs_path} ${cr_dir};
 
-# remove unecessary pcap files
+# remove unnecessary pcap files
 sudo rm ${cr_dir}virbr0*.pcap;
 
 # copy pcap file to trainee's directory

--- a/instantiation/vm_clone/vm_clone_xml.sh
+++ b/instantiation/vm_clone/vm_clone_xml.sh
@@ -61,7 +61,7 @@ echo "    </disk>" >> ${ABSPATH}images/${VM_ID}_config.xml;
 echo "    <controller type='ide' index='0'>" >> ${ABSPATH}images/${VM_ID}_config.xml;
 echo "      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>" >> ${ABSPATH}images/${VM_ID}_config.xml;
 echo "    </controller>" >> ${ABSPATH}images/${VM_ID}_config.xml;
-# This inteface setup is for connecting one vm from one server to another vm in another server
+# This interface setup is for connecting one vm from one server to another vm in another server
 for i in "${!ADDR_LIST[@]}"
 do
     IFS="." read -r -a  BIT_LIST <<< "${ADDR_LIST[i]}"

--- a/main/aws_instances.py
+++ b/main/aws_instances.py
@@ -88,7 +88,7 @@ def publicIp_get(client,ins_ids):
     return response['Reservations'][0]['Instances'][0]['PublicIpAddress']
 
 # Stop AWS instances
-# - input: ins_ids: list, the id of the instances to be stoped
+# - input: ins_ids: list, the id of the instances to be stopped
 # - output: status: dictionary, the id and the status
 def stop_instances(client,ins_ids):
     response = client.stop_instances(

--- a/main/cyris.py
+++ b/main/cyris.py
@@ -665,7 +665,7 @@ class CyberRangeCreation():
         return command_list, post_execute_program_list
 
     #########################################################################
-    # Generate commands for shuting down and undefining base images
+    # Generate commands for shutting down and undefining base images
     def shut_down_baseimg(self):
         shutdown_command = ""
         for guest in self.guests:

--- a/main/entities.py
+++ b/main/entities.py
@@ -409,7 +409,7 @@ class CloneInstance(object):
         return ip_list
 
     # Functions for generating ip addresses, gateway, and firewall rules for each guest 
-    # in the instance. Since there's no ip addressess in the beginning, it's mandatory to 
+    # in the instance. Since there's no ip addresses in the beginning, it's mandatory to
     # generate ip addresses before parsing gateway address for each guest in the instance.
     def setCloneGuestList(self, range_id):
         # Dictionary of <network_name>:<a list of members' ipaddr>.
@@ -418,7 +418,7 @@ class CloneInstance(object):
         nwname_nodes_dict = dict()
         # For each subnetwork/segment in the clone_subnetwork_list.
         # i is the index, start from 0. i is used as the third byte in the ipaddr.
-        # Bytes in ip addr couldnt be 0, that's why it's i+1.
+        # Bytes in ip addr couldn't be 0, that's why it's i+1.
         for i, subnw_element in enumerate(self.getCloneSubnwList()):
             # j is used as the index of node_element in each subnetwork/segment.
             # j is the fourth byte in the ipaddr.
@@ -529,7 +529,7 @@ class CloneInstance(object):
                     else:
                         fw_rule = "iptables -A FORWARD -m state -p tcp -s {0} -d {1} --state NEW,ESTABLISHED,RELATED -j ACCEPT".format(src_ip_str, dst_ip_str)
                     fwrule_list.append(fw_rule)
-                # Append the final rules as allowing all allowed traffic above comming back.
+                # Append the final rules as allowing all allowed traffic above coming back.
                 if len(fwrule_list) != 0:
                     fw_rule = "iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT"
                     fwrule_list.append(fw_rule)


### PR DESCRIPTION
## Summary
- correct typos in README and scripts
- fix spelling in python modules and shell scripts

## Testing
- `codespell -q 3`

------
https://chatgpt.com/codex/tasks/task_e_687713dbead88324abb6609a28842c84