### PR TITLE
Fix undefined variable bug in CyVarBox.project_URL

### DIFF
--- a/main/cyvar.py
+++ b/main/cyvar.py
@@ -60,8 +60,9 @@ class CyVarBox:
         return self.project(source, safe=1)
 
     def project_URL(self, source, safe=0):
-        owr = x
-        if "%" in x:
+        """Project variables in a URL string, safely handling quoting."""
+        owr = source
+        if "%" in source:
             orw = urllib.parse.unquote(owr)
             crw = self.project(orw, safe)
             cwr = urllib.parse.quote(crw)


### PR DESCRIPTION
## Summary
- fix typo in `project_URL` method
- add docstring for clarity

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687713cfbf1883248c276d3befc29a17